### PR TITLE
Add GitHub action that releases to PyPI on `Create Release`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: Release Package to PyPI.org
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-and-publish:
+    name: Build and Publish Package to PyPI.org
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+      - run: python -m pip install build twine && python -m build
+      - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
As explained in #126, you cannot release a package to PyPI with a direct dependency like `whisper-jax` (i.e. only installed using `pip install git+https://github.com/sanchit-gandhi/whisper-jax.git`).

To fix this, the package must be released to PyPI.
I added a GitHub Action to easily allow this to happen.
You only need to make sure you update the version here with every release:
https://github.com/sanchit-gandhi/whisper-jax/blob/45bff9df78a6a4f04144f405c74cf0ffa4c5fb52/whisper_jax/__init__.py#L16
Then create a tag for every important change then create a release from the tag.
I suggest using [Semantic Versioning 2.0.0](https://semver.org/) for choosing the next release version increment.

To test the release, I tried it on [TestPyPI](https://test.pypi.org/) and it worked releasing [v0.0.1](https://test.pypi.org/project/whisper-jax/) (I'll delete it or handover ownership to you if you want).

Now for the real [PyPI](https://pypi.org/), you must create a new project from [Publishing](https://test.pypi.org/manage/account/publishing/), at the bottom you will find this :point_down: 

![image](https://github.com/sanchit-gandhi/whisper-jax/assets/33587724/5ec1c815-ca1a-4d74-9635-dd2437100138)
Fill it with:
```
whisper-jax
sanchit-gandhi
whisper-jax
release.yml
```
And then we're good to go. It'll be ready to do the release from GitHub :)