### PR TITLE
fix dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ from setuptools import find_packages, setup
 _deps = [
     "transformers>=4.27.4",
     "flax",
+    "cached-property",
 ]
 
 _extras_dev_deps = [


### PR DESCRIPTION
add the dependency "cached-property" to `setup.py` because you imported it in `partitioner.py`