### PR TITLE
Enable pipeline for whisper-v3 model

### DIFF
--- a/whisper_jax/pipeline.py
+++ b/whisper_jax/pipeline.py
@@ -87,7 +87,7 @@ class FlaxWhisperPipline:
             self.checkpoint,
             _do_init=False,
             dtype=self.dtype,
-            input_shape = (1, self.feature_extractor.feature_size, 3000),
+            input_shape=(1, self.feature_extractor.feature_size, 3000),
         )
 
         self.max_length = max_length if max_length is not None else self.model.generation_config.max_length

--- a/whisper_jax/pipeline.py
+++ b/whisper_jax/pipeline.py
@@ -87,6 +87,7 @@ class FlaxWhisperPipline:
             self.checkpoint,
             _do_init=False,
             dtype=self.dtype,
+            input_shape = (1, self.feature_extractor.feature_size, 3000),
         )
 
         self.max_length = max_length if max_length is not None else self.model.generation_config.max_length


### PR DESCRIPTION
Use the feature_size property of the feature extractor to set the shape of standard input features instead of hardcoded (80, 3000)

Fixes crash when using the Whisper v3 model in the pipeline.
Behavior before the fix:

```
from whisper_jax import FlaxWhisperPipline

# next code line crashes with 
# ValueError: input_features.shape[1:], must be equal to (self.config.num_mel_bins, self.config.max_source_positions * 2) (got (80, 3000), but should be (128, 3000))
pipeline = FlaxWhisperPipline("openai/whisper-large-v3")
```