### PR TITLE
Reduce disk space use

### DIFF
--- a/app/monitor.sh
+++ b/app/monitor.sh
@@ -10,10 +10,13 @@ check_server() {
 	return 1
 }
 
+sudo mkdir -p /run/tmp/gradio
+
 while [ 1 ]
 do
   # periodically clear the /tmp directory for files created > 30 mins ago so it doesn't fill up
   sudo find /tmp -type f -amin +30 -delete
+  sudo find /run/tmp -type f -amin +30 -delete
 	check_server
 	if [[ $? -ne 1 ]]
 	then
@@ -24,8 +27,9 @@ do
 			pkill -9 python
 			#sudo lsof -t /dev/accel0 | xargs kill -9
 			sleep 5
-			mv log.txt log_`date +%Y%m%d%H%M%S`
-			TCMALLOC_LARGE_ALLOC_REPORT_THRESHOLD=10000000000 python ./app.py &> log.txt &
+			#mv log.txt log_`date +%Y%m%d%H%M%S`
+			cat /dev/null > log.txt
+			TCMALLOC_LARGE_ALLOC_REPORT_THRESHOLD=10000000000 GRADIO_TEMP_DIR="/run/tmp/gradio" python ./app.py &> log.txt &
 		else
 			echo "Waiting for restart"
 		fi


### PR DESCRIPTION
- Save tmp files to /run (a virtual filesystem)
- Don't preserve logs

Disk space is really tight in some instances.